### PR TITLE
feat(envelope): add envelope progress

### DIFF
--- a/lib/model/objects/envelope.dart
+++ b/lib/model/objects/envelope.dart
@@ -28,6 +28,8 @@ class Envelope {
     return amount - totalOperations;
   }
 
+  double get remainingRatio => amount > 0 ? remainingAmount / amount : 0;
+
   static Envelope fromMap(Map<String, Object?> e) {
     return Envelope(
       id: e['id'] as int,

--- a/lib/view/common/solid_button.dart
+++ b/lib/view/common/solid_button.dart
@@ -6,10 +6,12 @@ class SolidButton extends StatefulWidget {
     super.key,
     required this.text,
     required this.action,
+    this.color = mainColor,
   });
 
   final String text;
   final void Function() action;
+  final Color color;
 
   @override
   State<SolidButton> createState() => _SolidButtonState();
@@ -39,7 +41,7 @@ class _SolidButtonState extends State<SolidButton> {
       child: Container(
         width: double.infinity,
         decoration: BoxDecoration(
-          color: mainColor,
+          color: widget.color,
           borderRadius: BorderRadius.circular(8),
           boxShadow: _pressed
               ? null

--- a/lib/view/envelope/widgets/operation_row.dart
+++ b/lib/view/envelope/widgets/operation_row.dart
@@ -12,6 +12,7 @@ class OperationRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      leading: Icon(Icons.arrow_downward_outlined),
       title: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [

--- a/lib/view/home/widgets/bottom_sheet.dart
+++ b/lib/view/home/widgets/bottom_sheet.dart
@@ -4,21 +4,34 @@ import 'package:freenance/model/objects/budget.dart';
 import 'package:freenance/model/objects/envelope.dart';
 import 'package:freenance/view/home/widgets/envelope_row.dart';
 import 'package:freenance/view/theme/colors.dart';
-import 'package:freenance/view/common/solid_button.dart';
 // ignore: unused_import
 import 'package:freenance/view_model/providers.dart';
+
+const double _kHeight = 0.15;
+const double _kExpandedHeight = 0.6;
+
+class HomeBottomSheetController {
+  void Function() open = () {};
+  void Function() close = () {};
+}
 
 class HomeBottomSheet extends ConsumerStatefulWidget {
   const HomeBottomSheet({
     super.key,
     required this.currentBudget,
     required this.onAddEnvelope,
+    required this.onEditEnvelope,
     required this.onDeleteEnvelope,
+    required this.onSizeChanged,
+    required this.controller,
   });
 
   final Budget currentBudget;
   final void Function() onAddEnvelope;
+  final void Function(Envelope) onEditEnvelope;
   final void Function(Envelope) onDeleteEnvelope;
+  final void Function(bool)? onSizeChanged;
+  final HomeBottomSheetController controller;
 
   @override
   ConsumerState<HomeBottomSheet> createState() => _HomeBottomSheetState();
@@ -31,14 +44,33 @@ class _HomeBottomSheetState extends ConsumerState<HomeBottomSheet> {
   @override
   void initState() {
     super.initState();
-    _height = 0.2;
+    _height = _kHeight;
+    widget.controller.open = _openBottomSheet;
+    widget.controller.close = _closeBottomSheet;
+  }
+
+  void _openBottomSheet() {
+    setState(() {
+      _isExpanded = true;
+      _height = _kExpandedHeight;
+    });
+    widget.onSizeChanged?.call(_isExpanded);
+  }
+
+  void _closeBottomSheet() {
+    setState(() {
+      _isExpanded = false;
+      _height = _kHeight;
+    });
+    widget.onSizeChanged?.call(_isExpanded);
   }
 
   void _toggleBottomSheet() {
     setState(() {
       _isExpanded = !_isExpanded;
-      _height = _isExpanded ? 0.7 : 0.2;
+      _height = _isExpanded ? _kExpandedHeight : _kHeight;
     });
+    widget.onSizeChanged?.call(_isExpanded);
   }
 
   void _changeHeight(BuildContext context, double delta) {
@@ -54,11 +86,11 @@ class _HomeBottomSheetState extends ConsumerState<HomeBottomSheet> {
   void _onDragEnd() {
     if (_height > 0.5) {
       setState(() {
-        _height = 0.7;
+        _height = _kExpandedHeight;
       });
     } else {
       setState(() {
-        _height = 0.2;
+        _height = _kHeight;
       });
     }
   }
@@ -67,95 +99,90 @@ class _HomeBottomSheetState extends ConsumerState<HomeBottomSheet> {
   Widget build(BuildContext context) {
     return AnimatedContainer(
       duration: Duration(milliseconds: 200),
-      onEnd: () => setState(() {
-        if (_height == 0.7) {
-          _isExpanded = true;
-        } else {
-          _isExpanded = false;
-        }
-      }),
       width: double.infinity,
       height: MediaQuery.of(context).size.height * _height,
       decoration: BoxDecoration(
         color: Colors.white,
-        borderRadius: BorderRadius.zero,
+        borderRadius: _isExpanded
+            ? BorderRadius.only(
+                topLeft: Radius.circular(16),
+                topRight: Radius.circular(16),
+              )
+            : BorderRadius.zero,
       ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
+      child: CustomScrollView(
+        slivers: [
           // Bottom sheet drag handle
-          GestureDetector(
-            onTap: _toggleBottomSheet,
-            onVerticalDragUpdate: (details) =>
-                _changeHeight(context, details.delta.dy),
-            onVerticalDragEnd: (_) => _onDragEnd(),
-            child: Container(
-              width: 80,
-              height: 8,
-              margin: EdgeInsets.only(top: 8),
-              decoration: BoxDecoration(
-                color: Colors.grey,
-                borderRadius: BorderRadius.circular(4),
+          SliverToBoxAdapter(
+            child: GestureDetector(
+              onTap: _toggleBottomSheet,
+              onVerticalDragUpdate: (details) =>
+                  _changeHeight(context, details.delta.dy),
+              onVerticalDragEnd: (_) => _onDragEnd(),
+              child: Center(
+                child: Container(
+                  width: 80,
+                  height: 8,
+                  margin: EdgeInsets.only(top: 8),
+                  decoration: BoxDecoration(
+                    color: Colors.grey,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
               ),
             ),
           ),
-          ListTile(
-            title: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text(
-                  'Restant',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
+          SliverToBoxAdapter(
+            child: ListTile(
+              title: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Restant',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
-                ),
-                Text(
-                  '${widget.currentBudget.remainingAmount.toStringAsFixed(2)} €',
-                  style: TextStyle(
-                    color: mainColor,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w600,
+                  Text(
+                    '${widget.currentBudget.remainingAmount.toStringAsFixed(2)} €',
+                    style: TextStyle(
+                      color: mainColor,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
-                ),
-                Text(
-                  widget.currentBudget.remainingRatio.toStringAsFixed(0) + ' %',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w600,
+                  Text(
+                    widget.currentBudget.remainingRatio.toStringAsFixed(0) +
+                        ' %',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
+                ],
+              ),
+              subtitle: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: LinearProgressIndicator(
+                  minHeight: 32,
+                  borderRadius: BorderRadius.circular(8),
+                  value: widget.currentBudget.remainingRatio / 100,
+                  backgroundColor: Colors.grey[200],
+                  valueColor: AlwaysStoppedAnimation<Color>(mainColor),
                 ),
-              ],
-            ),
-            subtitle: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: LinearProgressIndicator(
-                minHeight: 32,
-                borderRadius: BorderRadius.circular(8),
-                value: widget.currentBudget.remainingRatio / 100,
-                backgroundColor: Colors.grey[200],
-                valueColor: AlwaysStoppedAnimation<Color>(mainColor),
               ),
             ),
           ),
 
           if (_isExpanded)
-            Expanded(
-              child: ListView.builder(
-                itemCount: widget.currentBudget.envelopes.length,
-                itemBuilder: (context, index) {
-                  return EnvelopeRow(
-                    envelope: widget.currentBudget.envelopes[index],
-                    onDelete: widget.onDeleteEnvelope,
-                  );
-                },
-              ),
-            ),
-          if (_isExpanded)
-            Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: SolidButton(
-                text: 'Ajouter',
-                action: widget.onAddEnvelope,
-              ),
+            SliverList.builder(
+              itemCount: widget.currentBudget.envelopes.length,
+              itemBuilder: (context, index) {
+                return EnvelopeRow(
+                  envelope: widget.currentBudget.envelopes[index],
+                  onTap: widget.onEditEnvelope,
+                  onDelete: widget.onDeleteEnvelope,
+                );
+              },
             ),
         ],
       ),

--- a/lib/view/home/widgets/envelope_row.dart
+++ b/lib/view/home/widgets/envelope_row.dart
@@ -1,15 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:freenance/model/objects/envelope.dart';
-import 'package:freenance/view/envelope/envelope_screen.dart';
+import 'package:freenance/view/theme/colors.dart';
 
 class EnvelopeRow extends StatelessWidget {
   const EnvelopeRow({
     super.key,
     required this.envelope,
     required this.onDelete,
+    required this.onTap,
   });
 
   final Envelope envelope;
+  final void Function(Envelope) onTap;
   final void Function(Envelope) onDelete;
 
   @override
@@ -31,16 +33,19 @@ class EnvelopeRow extends StatelessWidget {
         ),
       ),
       child: ListTile(
-        onTap: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => EnvelopeScreen(
-                envelopeId: envelope.id,
-              ),
+        onTap: () => onTap(envelope),
+        leading: Stack(
+          alignment: Alignment.center,
+          children: [
+            CircularProgressIndicator(
+              value: envelope.remainingRatio,
+              color: mainColor,
+              strokeWidth: 4,
+              strokeCap: StrokeCap.round,
             ),
-          );
-        },
-        leading: Icon(Icons.shopping_cart_outlined),
+            Icon(Icons.mail_outline),
+          ],
+        ),
         title: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/test/model/object/envelope_test.dart
+++ b/test/model/object/envelope_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:freenance/model/objects/envelope.dart';
+import 'package:freenance/model/objects/operation.dart';
+
+void main() {
+  group('Remaining ratio', () {
+    test('Remaining ratio is 0 when amount is 0', () {
+      final envelope = Envelope(
+        id: 1,
+        label: 'Envelope 1',
+        amount: 0,
+        operations: [],
+      );
+      expect(envelope.remainingRatio, 0);
+    });
+
+    test('Remaining ratio is 90 when amount is 100 and total operations is 10',
+        () {
+      final envelope = Envelope(
+        id: 1,
+        label: 'Envelope 1',
+        amount: 100,
+        operations: [
+          Operation(
+            id: 1,
+            label: 'Operation 1',
+            amount: 10,
+            date: DateTime.now(),
+          ),
+        ],
+      );
+      expect(envelope.remainingRatio, 0.9);
+    });
+  });
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the `HomeScreen` and `HomeBottomSheet` components by adding functionality to edit envelopes and improving the code maintainability with constants. The most important changes include adding a new method to edit envelopes, updating the `HomeBottomSheet` to support the new edit functionality, and refactoring the height constants for better readability.

Enhancements to `HomeScreen` and `HomeBottomSheet`:

* [`lib/view/home/home_screen.dart`](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R5): Added an import for `EnvelopeScreen` and added the `_editEnvelope` method to navigate to the `EnvelopeScreen` for editing envelopes. Updated the `HomeBottomSheet` instantiation to include the `onEditEnvelope` callback. [[1]](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R5) [[2]](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R173) [[3]](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R268-R277)
* [`lib/view/home/widgets/bottom_sheet.dart`](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bR11-R25): Introduced constants `_kHeight` and `_kExpandedHeight` for better readability and maintainability. Updated the `HomeBottomSheet` to accept `onEditEnvelope` as a required parameter and updated the `_toggleBottomSheet` and `_onDragEnd` methods to use the new constants. Modified the `AnimatedContainer` to adjust the border radius based on the expanded state. [[1]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bR11-R25) [[2]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bL34-R45) [[3]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bL57-R66) [[4]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bL71-R76) [[5]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bL81-L84) [[6]](diffhunk://#diff-860ca4e78fe883c2343073c236a11de524bdabc2522f23a96df3778e312eae8bR156)
* [`lib/view/home/widgets/envelope_row.dart`](diffhunk://#diff-3895543882eb39aa81328af2fd840fb70d5c71e85f91ad0af6051e372951be08R4-R15): Added `onTap` callback to `EnvelopeRow` to handle envelope editing. Updated the `ListTile` to use the `onTap` callback and display a `CircularProgressIndicator` indicating the remaining ratio of the envelope. [[1]](diffhunk://#diff-3895543882eb39aa81328af2fd840fb70d5c71e85f91ad0af6051e372951be08R4-R15) [[2]](diffhunk://#diff-3895543882eb39aa81328af2fd840fb70d5c71e85f91ad0af6051e372951be08L34-L43)

Additional changes:

* [`lib/model/objects/envelope.dart`](diffhunk://#diff-93c30f7220dc2cb4ec3a04f2b03564997fe4d9a27a351e24d80603cba9a67e8cR31-R32): Added a `remainingRatio` getter to the `Envelope` class to calculate the ratio of the remaining amount to the total amount.