### PR TITLE
chore(miscs): docs and pubspec

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
                 "isDefault": true
             },
             "problemMatcher": []
-        }
+        },
         {
             "label": "generate icon",
             "type": "shell",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # freenance
 
-A new Flutter project.
+A free personal finance management app.
+
+Freenance is a simple mobile app made for expense tracking.
+
+Create multiple Budgets, each budget can group several envelope and each envelope can group several operations.
+
+Budget => Envelope => Operation
 
 ## Getting Started
 
@@ -14,3 +20,54 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Generate sources
+
+This project use generated sources for:
+
+* state management
+* tests mocks
+* cucumber tests
+
+### Generate sources using command line
+
+Sources can be generated using the command line.
+
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+### Generate sources using VsCode tasks
+
+VsCode task has been created in order to generate sources using a simple shortcut.
+
+1. Type `Cmd` + `Shift` + `P` to show the VsCode command palette.
+2. Type `Run Task` select `Tasks: Run Task` and hit `Enter`
+3. Now select `generate sources` and hit `Enter`
+
+See [.vscode/tasks.json.vscode/tasks.json) for tasks definition.
+
+## Generate App icon
+
+![](./assets/icon/icon.png)
+
+This project use `flutter_launcher_icons` plugin from [pub.dev](https://pub.dev/) for icon management.
+
+The icon root asset is located at [assets/icon/icon.png](./assets/icon/icon.png)
+
+### Generate App icon using command line
+
+To change icon follow these steps:
+
+1. Replace the asset image in `assets/icon/icon.png`
+2. Run the commande `dart run flutter_launcher_icons`
+
+### Generate App icon using VcCode Tasks
+
+VsCode task has been created in order to generate App icon using a simple shortcut.
+
+1. Type `Cmd` + `Shift` + `P` to show the VsCode command palette.
+2. Type `Run Task` select `Tasks: Run Task` and hit `Enter`
+3. Now select `generate icon` and hit `Enter`
+
+See [.vscode/tasks.json.vscode/tasks.json) for tasks definition.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -134,14 +134,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -262,22 +254,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
-  drift:
-    dependency: transitive
-    description:
-      name: drift
-      sha256: c2d073d35ad441730812f4ea05b5dd031fb81c5f9786a4f5fb77ecd6307b6f74
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.22.1"
-  drift_dev:
-    dependency: "direct dev"
-    description:
-      name: drift_dev
-      sha256: f4ab5d6976b1e31551ceb82ff597a505bda7818ff4f7be08a1da9d55eb6e730c
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.22.1"
   fake_async:
     dependency: transitive
     description:
@@ -321,7 +297,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_launcher_icons:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: flutter_launcher_icons
       sha256: "31cd0885738e87c72d6f055564d37fabcdacee743b396b78c7636c169cac64f5"
@@ -684,14 +660,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  recase:
-    dependency: transitive
-    description:
-      name: recase
-      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
   riverpod:
     dependency: transitive
     description:
@@ -913,22 +881,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
-  sqlite3:
-    dependency: transitive
-    description:
-      name: sqlite3
-      sha256: cb7f4e9dc1b52b1fa350f7b3d41c662e75fc3d399555fa4e5efcf267e9a4fbb5
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.0"
-  sqlparser:
-    dependency: transitive
-    description:
-      name: sqlparser
-      sha256: "4cad4b2c5f63dc9ea1a8dcffb58cf762322bea5dd8836870164a65e913bdae41"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.40.0"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: ^3.6.0
@@ -39,12 +39,13 @@ dependencies:
   sqflite: ^2.4.1
   package_info_plus: ^8.1.2
   shared_preferences: ^2.3.4
-  flutter_launcher_icons: ^0.14.2
+  
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  flutter_launcher_icons: ^0.14.2
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your
@@ -55,7 +56,6 @@ dev_dependencies:
   build_runner: ^2.4.13
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3
-  drift_dev: ^2.22.1
   integration_test:
     sdk: flutter
   pickled_cucumber: ^1.1.0


### PR DESCRIPTION
This pull request includes several updates to the project, focusing on documentation improvements, version updates, and task configurations. The most important changes are as follows:

Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9): Improved project description and added detailed instructions for generating sources and app icons, including command line and VsCode task methods. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R73)

Version updates:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L19-R19): Updated the project version from `1.0.1+2` to `1.0.2+3`.

Task configurations:
* [`.vscode/tasks.json`](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL13-R13): Added a new task for generating icons and fixed a JSON formatting issue.

Dependency management:
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L42-R48): Moved `flutter_launcher_icons` from `dependencies` to `dev_dependencies` and removed `drift_dev` from `dev_dependencies`. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L42-R48) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L58)