### PR TITLE
feat(envelope): auto open envelop screen on creation

### DIFF
--- a/lib/view/home/home_screen.dart
+++ b/lib/view/home/home_screen.dart
@@ -59,6 +59,11 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
     List<Budget> budgetList,
   ) {
     final mainColor = ref.watch(colorNotifierProvider).mainColor;
+    ref.listen(envelopeCreatedProvider, (oldValue, newValue) {
+      if (oldValue != newValue) {
+        Voyager.pushEnvelope(context, newValue!);
+      }
+    });
 
     return Scaffold(
       backgroundColor: mainColor,
@@ -286,6 +291,8 @@ class HomeScreenState extends ConsumerState<HomeScreen> {
           values.$2,
         );
     ref.invalidate(budgetListProvider);
+
+    ref.read(envelopeCreatedProvider.notifier).envelopeCreated(budget.id);
   }
 
   void _editEnvelope(Envelope envelope) {

--- a/lib/view_model/providers.dart
+++ b/lib/view_model/providers.dart
@@ -35,6 +35,23 @@ Future<Envelope> envelope(Ref ref, int envelopeId) async {
 }
 
 @riverpod
+class EnvelopeCreated extends _$EnvelopeCreated {
+  @override
+  Envelope? build() {
+    return null;
+  }
+
+  Future<void> envelopeCreated(int budgetId) async {
+    final budgetList = await ref.read(budgetListProvider.future);
+    final budget = budgetList.firstWhere((b) => b.id == budgetId);
+    final maxEnvelopeId =
+        budget.envelopes.map((e) => e.id).reduce((a, b) => a > b ? a : b);
+    final envelope = budget.envelopes.firstWhere((e) => e.id == maxEnvelopeId);
+    state = envelope;
+  }
+}
+
+@riverpod
 class ColorNotifier extends _$ColorNotifier {
   @override
   ColorTheme build() {

--- a/lib/view_model/providers.g.dart
+++ b/lib/view_model/providers.g.dart
@@ -205,6 +205,22 @@ class _EnvelopeProviderElement
   int get envelopeId => (origin as EnvelopeProvider).envelopeId;
 }
 
+String _$envelopeCreatedHash() => r'3344d63b3174ccb8b04bdb4aec69ed85c9fa2657';
+
+/// See also [EnvelopeCreated].
+@ProviderFor(EnvelopeCreated)
+final envelopeCreatedProvider =
+    AutoDisposeNotifierProvider<EnvelopeCreated, Envelope?>.internal(
+  EnvelopeCreated.new,
+  name: r'envelopeCreatedProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$envelopeCreatedHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$EnvelopeCreated = AutoDisposeNotifier<Envelope?>;
 String _$colorNotifierHash() => r'674a7a81ff505bdd8fd82a4f77edf1d3ea162c0d';
 
 /// See also [ColorNotifier].

--- a/test/features/envelope.feature
+++ b/test/features/envelope.feature
@@ -1,0 +1,7 @@
+Freature: Envelope
+
+    Scenario: Create an envelope
+    Given I start my App
+    And I wait for the loading to finish
+    When I create a new envelope named "Mon enveloppe" with 42.0 amound
+    Then I should see the envelope screen openning

--- a/test/step_definitions.dart
+++ b/test/step_definitions.dart
@@ -5,6 +5,7 @@ import 'package:freenance/app.dart';
 import 'package:freenance/model/objects/budget.dart';
 import 'package:freenance/model/objects/envelope.dart';
 import 'package:freenance/model/objects/operation.dart';
+import 'package:freenance/view/envelope/envelope_screen.dart';
 import 'package:freenance/view/home/widgets/bottom_sheet.dart';
 import 'package:freenance/view/home/widgets/envelope_row.dart';
 import 'package:freenance/view_model/providers.dart';
@@ -53,6 +54,7 @@ class FreenanceStepDefinitions {
         .thenAnswer((_) async => Future.value(fakeEnvelope));
   }
 
+  @Given('I start my App')
   @When('I start my App')
   Future<void> iStartMyApp(WidgetTester tester) async {
     await tester.pumpWidget(
@@ -108,5 +110,33 @@ class FreenanceStepDefinitions {
 
     expect(find.text('Mon Opération'), findsOneWidget);
     expect(find.text('- ${amount.toStringAsFixed(2)} €'), findsOneWidget);
+  }
+
+  @When('I create a new envelope named {string} with {float} amound')
+  Future<void> iCreateANewEnvelopeNamedWithAmound(
+    WidgetTester tester,
+    String label,
+    double amount,
+  ) async {
+    // Click on add button
+    await tester.tap(find.text('Ajouter une enveloppe'));
+    await tester.pumpAndSettle();
+
+    // Fill the label
+    await tester.enterText(find.text('Nouvelle enveloppe'), label);
+    await tester.pumpAndSettle();
+
+    // Fill the amount
+    await tester.enterText(find.text('0.0'), amount.toString());
+    await tester.pumpAndSettle();
+
+    // Click on validate button
+    await tester.tap(find.text('Valider'));
+    await tester.pumpAndSettle();
+  }
+
+  @Then('I should see the envelope screen openning')
+  Future<void> iShouldSeeTheEnvelopeScreenOpenning(WidgetTester tester) async {
+    expect(find.byType(EnvelopeScreen), findsOneWidget);
   }
 }

--- a/test/step_definitions.pickled.dart
+++ b/test/step_definitions.pickled.dart
@@ -37,6 +37,24 @@ runFeatures() {
     },
   );
   group(
+    'Envelope',
+    () {
+      testWidgets(
+        'Create an envelope',
+        (WidgetTester widgetTester) async {
+          await steps.iStartMyApp(widgetTester);
+          await steps.iWaitForTheLoadingToFinish(widgetTester);
+          await steps.iCreateANewEnvelopeNamedWithAmound(
+            widgetTester,
+            'Mon enveloppe',
+            42.0,
+          );
+          await steps.iShouldSeeTheEnvelopeScreenOpenning(widgetTester);
+        },
+      );
+    },
+  );
+  group(
     'App starts',
     () {
       testWidgets(


### PR DESCRIPTION
This pull request introduces several changes to the `lib/view/home/home_screen.dart`, `lib/view_model/providers.dart`, and test files to support the creation and testing of a new envelope feature. The most important changes include adding a new provider for envelope creation, updating the home screen to listen for envelope creation events, and adding tests for the new functionality.

### Feature Implementation:

* [`lib/view/home/home_screen.dart`](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R62-R66): Added a listener for `envelopeCreatedProvider` to handle envelope creation and navigation. Also, invoked the envelope creation method when a new budget is created. [[1]](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R62-R66) [[2]](diffhunk://#diff-2fc21a2f904dc90a0757e8ab21669c65aedcc0ba470c7a27da00405b7364ad52R294-R295)
* [`lib/view_model/providers.dart`](diffhunk://#diff-30308147ec2572263ca2208e7b141b34d1c975beabc7ce4cf2db39b602a0ae7eR37-R53): Introduced the `EnvelopeCreated` provider to manage the state of newly created envelopes and handle the logic for finding the latest envelope in a budget.
* [`lib/view_model/providers.g.dart`](diffhunk://#diff-4ca4cb9abb854a633bd2729b51421d65317a0cf0e14351979e41a35d69b3de6aR208-R223): Added the `envelopeCreatedProvider` definition and hash function.

### Testing:

* [`test/features/envelope.feature`](diffhunk://#diff-c64eb7ce66b3c8e51a1a09e3db7c842096a882b8b1a56373cbf7ecdcfab70fb4R1-R7): Added a new feature scenario for creating an envelope, including steps to start the app, create an envelope, and verify the envelope screen is displayed.
* [`test/step_definitions.dart`](diffhunk://#diff-18251d73bbf62e2e6020dd80fa37e125159c6c29a2e0de00e22c8d903764ef4cR8): Added step definitions for starting the app, creating a new envelope, and verifying the envelope screen. [[1]](diffhunk://#diff-18251d73bbf62e2e6020dd80fa37e125159c6c29a2e0de00e22c8d903764ef4cR8) [[2]](diffhunk://#diff-18251d73bbf62e2e6020dd80fa37e125159c6c29a2e0de00e22c8d903764ef4cR57) [[3]](diffhunk://#diff-18251d73bbf62e2e6020dd80fa37e125159c6c29a2e0de00e22c8d903764ef4cR114-R137)
* [`test/step_definitions.pickled.dart`](diffhunk://#diff-96e385637ea2164953b7fc5b2343c50d097782128b70c47afbc02a3a892765e2R39-R56): Added a test group for the envelope feature, including a test for creating an envelope.